### PR TITLE
Fixes build script for push action to succeed

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,12 +6,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           fetch-depth: 1
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@e42168ca1a833395367a6bce0db2a62f7fe4da81 # v3.11.0
         with:
-          java-version: 13
+          java-version: 17
+          distribution: oracle
       - run: |
           ./gradlew build
           ./gradlew combinedjavadoc

--- a/adapter/image/src/main/java/at/jku/isse/ecco/adapter/image/ImageViewer.java
+++ b/adapter/image/src/main/java/at/jku/isse/ecco/adapter/image/ImageViewer.java
@@ -62,7 +62,8 @@ public class ImageViewer extends BorderPane implements ArtifactViewer {
 			this.setTop(saveButton);
 			this.setCenter(imageView);
 			this.setBackground(Background.EMPTY);
-		} else if (node.getArtifact().getData() instanceof ImageArtifactData imageArtifactData) {
+		} else if (node.getArtifact().getData() instanceof ImageArtifactData) {
+			ImageArtifactData imageArtifactData = (ImageArtifactData) node.getArtifact().getData();
 
 			if (imageArtifactData.getType().equals(ImageReader.TYPE_COLOR)) {
 				this.setCenter(null);

--- a/build.gradle
+++ b/build.gradle
@@ -27,8 +27,8 @@ subprojects {
 	apply plugin: 'nebula.ospackage'
 	//apply plugin: 'checkstyle'
 
-	sourceCompatibility = JavaVersion.VERSION_17
-	targetCompatibility = JavaVersion.VERSION_17
+	sourceCompatibility = JavaVersion.VERSION_13
+	targetCompatibility = JavaVersion.VERSION_13
 
 	repositories {
 		mavenCentral()
@@ -167,17 +167,20 @@ subprojects {
 			}
 
 			from({
-				def temp = project.configurations.runtime;
-				project.configurations.findAll { it.name.equals("runtime") }.collectMany {
+				def temp = project.configurations.runtimeClasspath;
+
+				project.configurations.findAll { it.name.equals("runtimeClasspath") }.collectMany {
 					it.allDependencies
 				}.findAll { it instanceof ProjectDependency }.collect {
-					it.dependencyProject.configurations.runtime
+					(it as ProjectDependency).dependencyProject.configurations.runtimeClasspath
 				}.each { temp = temp - it };
-				project.configurations.findAll { it.name.equals("runtime") }.collectMany {
+
+				project.configurations.findAll { it.name.equals("runtimeClasspath") }.collectMany {
 					it.allDependencies
-				}.findAll { it instanceof ProjectDependency }.collect { it.dependencyProject.jar.outputs.files }.each {
+				}.findAll { it instanceof ProjectDependency }.collect { (it as ProjectDependency).dependencyProject.jar.outputs.files }.each {
 					temp = temp - it;
 				};
+
 				return temp;
 			}) {
 				addParentDirs false
@@ -208,7 +211,7 @@ subprojects {
 
 	task linuxZip(type: Zip, group: 'packaging') {
 		archiveClassifier = 'linux'
-		into(archiveName - ('.' + archiveExtension)) {
+		into(archiveFileName.get() - ('.' + archiveExtension)) {
 			from project.jar
 			from project.configurations.runtimeClasspath
 		}
@@ -216,7 +219,7 @@ subprojects {
 
 	task windowsZip(type: Zip, group: 'packaging') {
 		archiveClassifier = 'windows'
-		into(archiveName - ('.' + archiveExtension)) {
+		into(archiveFileName.get() - ('.' + archiveExtension)) {
 			from project.jar
 			from project.configurations.runtimeClasspath
 		}

--- a/gui/src/main/java/at/jku/isse/ecco/gui/view/ArtifactsView.java
+++ b/gui/src/main/java/at/jku/isse/ecco/gui/view/ArtifactsView.java
@@ -458,12 +458,16 @@ public class ArtifactsView extends BorderPane implements EccoListener {
 
         @Override
         public Object getPropertyValue(String propertyName) {
-            return switch (propertyName) {
-                case "color" -> colorProperty().getValue();
-                case "selected" -> selectedProperty().getValue();
-                case "numArtifacts" -> numArtifactsProperty().getValue();
-                default -> null;
-            };
+            switch (propertyName) {
+                case "color":
+                    return colorProperty().getValue();
+                case "selected":
+                    return selectedProperty().getValue();
+                case "numArtifacts":
+                    return numArtifactsProperty().getValue();
+                default:
+                    return null;
+            }
         }
 
         public boolean isSelected() {

--- a/web/src/main/java/at/jku/isse/ecco/web/domain/repository/OperationRepository.java
+++ b/web/src/main/java/at/jku/isse/ecco/web/domain/repository/OperationRepository.java
@@ -43,7 +43,7 @@ public class OperationRepository extends AbstractRepository {
      * ein Fehler geworfen werden, der besagt, dass das Repo unter diesem Verzechnis nicht existiert
      *
      * Umformung der Plugins im Bezug auf die Namen und der Beschreibungen ist nötig, da Jackson nicht weiß, wie er aus der Klasse ein JSON Object machen soll...
-     * Error aus einem Test-Request:No serializer found for class at.jku.isse.ecco.adapter.file.FileModule and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: at.jku.isse.ecco.web.domain.model.OpenOperationResponse["artifactPlugins"]->java.util.ArrayList[0]->at.jku.isse.ecco.adapter.file.FilePlugin["module"])
+     * Error aus einem Test-Request:No serializer found for class at.jku.isse.ecco.adapter.file.FileModule and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: at.jku.isse.ecco.web.domain.model.OpenOperationResponse["artifactPlugins"]-&gt;java.util.ArrayList[0]-&gt;at.jku.isse.ecco.adapter.file.FilePlugin["module"])
      *
      *
      * @param baseDirectory Das Verzeichnis, dass zum Ecco-Repo zeigt oder zeigen soll,


### PR DESCRIPTION
This pull request would fix the GitHub "push" action, so that the build succeeds and https://github.com/jku-isse/ecco/pull/41 can run through.
The changes are as follows:

First, the action's versions are pinned to the commit-hashes, as suggested in https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

Then, the code is made Java 13 compatible by removing the experimental switch expression and the usage of instance-of pattern matching. This change is necessary, so the `sourceCompatibility` and `targetCompatibility` can be set to 13. This, in turn, is necessary, because gradle 7 does not support higher versions. Gradle 8 cannot be used trivially, as far as I can see, because some dependencies are outdated and are therefore incompatible with gradle 8. I'd suggest using a bot like Dependabot to automatically update those dependency in the future, as doing so manually would be quite tedious.

Furthmore, the ">" sign in the javadocs has been replaced with the appropriate html encoding, because the `combinedjavadoc` task was complaining about it.

Finally, in finding the project dependencies for `combinedrpm` has been updated to reflect the changes made in gradle 7, according to https://docs.gradle.org/current/userguide/upgrading_version_6.html