### PR TITLE
Binds REST api to 0.0.0.0 instead of localhost

### DIFF
--- a/web/src/main/java/at/jku/isse/ecco/web/server/EccoWebServer.java
+++ b/web/src/main/java/at/jku/isse/ecco/web/server/EccoWebServer.java
@@ -10,7 +10,7 @@ import java.net.URI;
 public class EccoWebServer {
 
 	// Base URI the Grizzly HTTP server will listen on
-	private static final URI BASE_URI = URI.create("http://localhost:8080/rest/api");
+	private static final URI BASE_URI = URI.create("http://0.0.0.0:8080/rest/api");
 
 	public static void main(String[] args) throws IOException, InterruptedException {
 		final EccoApplication eccoApplication = new EccoApplication();


### PR DESCRIPTION
Allows connecting from the outside and not only from localhost so the rest api is accessible from, i.e., a docker container.
