### PR TITLE
Adds a pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+# Description
+
+Summary of changes and / or of what was implemented.
+
+## Testing
+
+Explain how your changes can be tested.
+This can include automatic (e.g. unit-) tests or manual tasks.
+If the changes don't contain changes to source code this section can be disregarded.
+
+## Checklist
+
+- [ ] I have added unit tests for new code
+- [ ] I have adapted unit tests for changed code
+- [ ] I have deleted all code that was commented out


### PR DESCRIPTION
# Description

Adds a pull request template that should (if I added the file correctly) be inserted into the text field, whenever someone opens a new pull request.

## Testing

Since it's a GitHub thing it can only really be tested after it has been merged.
Testing it would only be possible with the workaround of forking this repository, placing the template into this location, pushing it to the fork's master branch and then open a PR on the fork.

## Checklist

- [x] I have added unit tests for new code
- [x] I have adapted unit tests for changed code
- [x] I have deleted all code that was commented out
