### PR TITLE
Change renovate config to use renovate-base as base branch

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,6 @@
       "automergeType": "pr",
       "platformAutomerge": true
     }
-  ]
+  ],
+  "baseBranches": ["renovate-base"]
 }


### PR DESCRIPTION
# Description

For the renovate-bot to not break the main branch with renovations, the config was changed to use the branch "renovate-base" as base branch. This is supposed to be a temporary solution until there are enough tests the renovate-bot can use to check updates.

## Testing

The tool renovate-config-validator was used to validate the config file.

## Checklist

- [x] I have added unit tests for new code (unit tests not applicable)
- [x] I have adapted unit tests for changed code (unit tests not applicable)
- [x] I have deleted all code that was commented out
